### PR TITLE
test defns: Fix commitment test to not always fail

### DIFF
--- a/test_definitions/finance/11_commitment.feature
+++ b/test_definitions/finance/11_commitment.feature
@@ -5,4 +5,4 @@ Feature: Commitment
     Given an IATI activity
      And the activity is current
      And `activity-status/@code` is one of 2, 3 or 4
-     Then `transaction/transaction-type[@code="2"]` should be present and of non-zero value
+     Then `transaction[transaction-type/@code="2"]` should be present and of non-zero value

--- a/tests/finance/test_commitments.py
+++ b/tests/finance/test_commitments.py
@@ -1,0 +1,98 @@
+from os.path import dirname, join, realpath
+from unittest import TestCase
+
+from bdd_tester import BDDTester
+from lxml import etree
+
+
+class TestCommitments(TestCase):
+    def setUp(self):
+        self.FILEPATH = dirname(realpath(__file__))
+        steps_path = join(self.FILEPATH, '..', '..', 'test_definitions',
+                          'step_definitions.py')
+        feature_path = join(self.FILEPATH, '..', '..', 'test_definitions',
+                            'finance',
+                            '11_commitment.feature')
+
+        tester = BDDTester(steps_path)
+        feature = tester.load_feature(feature_path)
+        self.test = feature.tests[0]
+
+    def test_commitment_no_value(self):
+        xml = '''
+        <iati-activity>
+          <activity-status code="2"/>
+          <transaction>
+            <transaction-type code="2"/>
+          </transaction>
+        </iati-activity>
+        '''
+
+        activity = etree.fromstring(xml)
+        result = self.test(activity)
+
+        assert result is False
+
+    def test_commitment_zero_value(self):
+        xml = '''
+        <iati-activity>
+          <activity-status code="2"/>
+          <transaction>
+            <transaction-type code="2"/>
+            <value>0</value>
+          </transaction>
+        </iati-activity>
+        '''
+
+        activity = etree.fromstring(xml)
+        result = self.test(activity)
+
+        assert result is False
+
+    def test_commitment_zero_value_decimal(self):
+        xml = '''
+        <iati-activity>
+          <activity-status code="2"/>
+          <transaction>
+            <transaction-type code="2"/>
+            <value>0.0</value>
+          </transaction>
+        </iati-activity>
+        '''
+
+        activity = etree.fromstring(xml)
+        result = self.test(activity)
+
+        assert result is False
+
+    def test_commitment_non_zero(self):
+        xml = '''
+        <iati-activity>
+          <activity-status code="2"/>
+          <transaction>
+            <transaction-type code="2"/>
+            <value>123.45</value>
+          </transaction>
+        </iati-activity>
+        '''
+
+        activity = etree.fromstring(xml)
+        result = self.test(activity)
+
+        assert result is True
+
+    def test_commitment_not_present(self):
+        xml = '''
+        <iati-activity>
+          <activity-status code="2"/>
+          <transaction>
+            <transaction-type code="3"/>
+          </transaction>
+        </iati-activity>
+        '''
+
+        activity = etree.fromstring(xml)
+        result = self.test(activity)
+
+        assert result is False
+

--- a/tests/finance/test_disbursements_and_expenditures.py
+++ b/tests/finance/test_disbursements_and_expenditures.py
@@ -18,6 +18,22 @@ class TestDisbursementsAndExpenditures(TestCase):
         feature = tester.load_feature(feature_path)
         self.test = feature.tests[0]
 
+    def test_disbursement_or_expenditure(self):
+        xml = '''
+        <iati-activity>
+          <activity-status code="2"/>
+          <transaction>
+            <transaction-type code="{}"/>
+          </transaction>
+        </iati-activity>
+        '''
+
+        for transaction_type in ['3', '4']:
+            activity = etree.fromstring(xml.format(transaction_type))
+            result = self.test(activity)
+
+            assert result is True
+
     def test_disbursement_or_expenditure_non_zero(self):
         xml = '''
         <iati-activity>


### PR DESCRIPTION
This was accidentally broken in:
https://github.com/pwyf/2024-Index-indicator-definitions/commit/dd7aa9d494ce8e692c00b59f8d55748d57bad3a3